### PR TITLE
Поправлена ошибка переопределения класса Error в PHP версии 7.X

### DIFF
--- a/include/php/bill_util.php
+++ b/include/php/bill_util.php
@@ -151,7 +151,7 @@ function RandomStr($size = 8) {
     return $result;
 }
 
-class Error extends Exception
+class ISPErrorException extends Exception
 {
 	private $m_object = "";
 	private $m_value = "";

--- a/include/php/bill_util.php
+++ b/include/php/bill_util.php
@@ -205,13 +205,13 @@ class DB extends mysqli {
 	public function __construct($host, $user, $pass, $db) {
 		parent::init();
 		if (!parent::options(MYSQLI_INIT_COMMAND, "SET AUTOCOMMIT = 1"))
-			throw new Error("MYSQLI_INIT_COMMAND Fail");
+			throw new ISPErrorException("MYSQLI_INIT_COMMAND Fail");
 
 		if (!parent::options(MYSQLI_OPT_CONNECT_TIMEOUT, 5))
-			throw new Error("MYSQLI_OPT_CONNECT_TIMEOUT Fail");
+			throw new ISPErrorException("MYSQLI_OPT_CONNECT_TIMEOUT Fail");
 
 		if (!parent::real_connect($host, $user, $pass, $db))
-			throw new Error("Connection ERROR. ".mysqli_connect_errno().": ".mysqli_connect_error());
+			throw new ISPErrorException("Connection ERROR. ".mysqli_connect_errno().": ".mysqli_connect_error());
 
 		Debug("MySQL connection established");
 	}

--- a/paymethod/qiwipull/cgi/qiwipullpayment.php
+++ b/paymethod/qiwipull/cgi/qiwipullpayment.php
@@ -12,7 +12,7 @@ $client_ip = ClientIp();
 $param = CgiInput();
 
 if ($param["auth"] == "") {
-	throw new Error("no auth info");
+	throw new ISPErrorException("no auth info");
 } else {
 	$info = LocalQuery("payment.info", array("elid" => $param["elid"], ));
 	$elid = (string)$info->payment[0]->id;

--- a/paymethod/qiwipull/paymethods/pmqiwipull.php
+++ b/paymethod/qiwipull/paymethods/pmqiwipull.php
@@ -78,11 +78,11 @@ try {
 		Debug($PRV_ID);
 
 		if (!preg_match("/^\d+$/", $API_ID)) {
-			throw new Error("value", "API_ID", $API_ID);
+			throw new ISPErrorException("value", "API_ID", $API_ID);
 		}
 
 		if (!preg_match("/^\d+$/", $PRV_ID)) {
-			throw new Error("value", "PRV_ID", $PRV_ID);
+			throw new ISPErrorException("value", "PRV_ID", $PRV_ID);
 		}
 
 		echo $paymethod_form->asXML();
@@ -141,10 +141,10 @@ try {
 		if ($out_xml->result_code == "0") {
 			LocalQuery("payment.setinpay", array("elid" => $payment_id, ));
 		} else {
-			throw new Error("payment_process_error", "", "", array("error_msg" => $out_xml->description));
+			throw new ISPErrorException("payment_process_error", "", "", array("error_msg" => $out_xml->description));
 		}
 	} else {
-		throw new Error("unknown command");
+		throw new ISPErrorException("unknown command");
 	}
 } catch (Exception $e) {
 	echo $e;

--- a/processing/registrar/processing/pmregistrar.php
+++ b/processing/registrar/processing/pmregistrar.php
@@ -65,7 +65,7 @@ function ItemParam($db, $iid) {
 					   WHERE i.id=" . $iid);
 
 	if ($res == FALSE)
-		throw new Error("query", $db->error);
+		throw new ISPErrorException("query", $db->error);
 
     $param = $res->fetch_assoc();
 
@@ -188,7 +188,7 @@ try {
 		try {
 			new DB($dbhost, $username, $password, $dbname);
 		} catch (Exception $e) {
-			throw new Error("invalid_login_or_passwd");
+			throw new ISPErrorException("invalid_login_or_passwd");
 		}
 
 		echo $default_xml_string;
@@ -261,7 +261,7 @@ try {
 		$tld = $options['param'];
 
 		if ($tld == "my" && $param_xml->customer_my_agree != "on")
-			throw new Error("customer_agree", "customer_my_agree");
+			throw new ISPErrorException("customer_agree", "customer_my_agree");
 
 	} elseif ($command == "open" || $command == "transfer") {
 		// Check if domain ixist in database and create it
@@ -274,7 +274,7 @@ try {
 		$ddb = GetDomainConnection($item_param["item_module"]);
 
 		if ($ddb->query("SELECT COUNT(*) FROM domain WHERE status != 'deleted' AND name = '" . $ddb->real_escape_string($item_param["domain"]) . "'")->fetch_row()[0] > 0)
-			throw new Error("exist");
+			throw new ISPErrorException("exist");
 
 		// Add service profiles into test DB (in real world send API requests to registrar)
 		$profile_params = ItemProfiles($db, $iid, $item_param["item_module"]);
@@ -305,7 +305,7 @@ try {
 																				  "externalpassword" => $externalpassword,
 																				  "sok" => "ok", ));
 					} else {
-						throw new Error("query", $db->error);
+						throw new ISPErrorException("query", $db->error);
 					}
 				}
 
@@ -337,7 +337,7 @@ try {
 			// open service in BILLmanager
 			LocalQuery("domain.open", array("elid" => $item, "sok" => "ok"));
 		} else {
-			throw new Error("query", $db->error);
+			throw new ISPErrorException("query", $db->error);
 		}
 	} elseif ($command == "suspend") {
 		// Update status of domain in test DB. Suspend domain if possible via registrar API or cancel auto prolong if need


### PR DESCRIPTION
Класс Error заменен на ISPErrorException - в PHP версии 7.X (тестировалось на PHP 7.4.2) запрещено заменять встроенный класс Error.
Сама ошибка: Fatal error: Cannot declare class Error, because the name is already in use.